### PR TITLE
Increase heap size in tarfind

### DIFF
--- a/build_all.py
+++ b/build_all.py
@@ -706,7 +706,7 @@ def link_benchmark(bench):
             cwd=abs_bd_b,
             timeout=gp['timeout'],
             check=True
-        
+        )
         log.debug(res.stdout.decode('utf-8'))
         log.debug(res.stderr.decode('utf-8'))
 

--- a/src/tarfind/tarfind.c
+++ b/src/tarfind/tarfind.c
@@ -20,7 +20,7 @@
 #define N_SEARCHES 5
 
 /* BEEBS heap is just an array */
-#define HEAP_SIZE 8995
+#define HEAP_SIZE 16384
 static char heap[HEAP_SIZE];
 
 void


### PR DESCRIPTION
Previous value was to small for Rocket chip simulation

Signed-off-by: Maciej Dudek <mdudek@antmicro.com>